### PR TITLE
chore(slack-events,slack-textract): update README instructions to create secret

### DIFF
--- a/src/slack-events/README.md
+++ b/src/slack-events/README.md
@@ -13,7 +13,7 @@ secret.
 This can be done with the [AWS CLI](https://aws.amazon.com/cli/):
 
 ```
-aws secretsmanager create-secret --name my-slack-app --secret-string '{"appId":"<id>","signingSecret":"<secret>","botToken":"<token>"}'
+aws secretsmanager create-secret --name my-slack-app --secret-string <signing secret>
 ```
 
 ### 2. Add the SlackEvents construct

--- a/src/slack-textract/README.md
+++ b/src/slack-textract/README.md
@@ -15,7 +15,7 @@ secret.
 This can be done with the [AWS CLI](https://aws.amazon.com/cli/):
 
 ```
-aws secretsmanager --name my-slack-app --secret-string <signing secret>
+aws secretsmanager create-secret --name my-slack-app --secret-string '{"appId":"<id>","signingSecret":"<secret>","botToken":"<token>"}'
 ```
 
 ### 2. Add the SlackTextract construct


### PR DESCRIPTION
The instructions for `SlackEvents` and `SlackTextract` were inverted.