### PR TITLE
chore: remove bundled dependencies

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -21,6 +21,10 @@ const project = new AwsCdkConstructLibrary({
     'got',
     '@slack/web-api',
   ],
+  peerDeps: [
+    'got',
+    '@slack/web-api',
+  ],
   devDeps: [
     "@types/aws-lambda",
     "@types/tsscmp",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -17,7 +17,7 @@ const project = new AwsCdkConstructLibrary({
     "@aws-cdk/aws-logs",
     "@aws-cdk/core",
   ],
-  bundledDeps: [
+  deps: [
     'got',
     '@slack/web-api',
   ],

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "@aws-cdk/aws-lambda-nodejs": "^1.75.0",
     "@aws-cdk/aws-logs": "^1.75.0",
     "@aws-cdk/core": "^1.75.0",
-    "constructs": "^3.2.27"
+    "@slack/web-api": "^5.13.0",
+    "constructs": "^3.2.27",
+    "got": "^11.8.0"
   },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "^1.75.0",

--- a/package.json
+++ b/package.json
@@ -80,10 +80,7 @@
     "@slack/web-api": "^5.13.0",
     "got": "^11.8.0"
   },
-  "bundledDependencies": [
-    "@slack/web-api",
-    "got"
-  ],
+  "bundledDependencies": [],
   "keywords": [
     "cdk"
   ],


### PR DESCRIPTION
Lambda runtime dependencies do not have to be bundled.