### PR TITLE
docs(slack-textract): update README

### DIFF
--- a/src/slack-textract/README.md
+++ b/src/slack-textract/README.md
@@ -44,9 +44,9 @@ export class MyStack extends cdk.Stack {
 Look for the API endoint in your stack outputs and use it to enable event subscriptions
 in your Slack app and subscribe to the `file_shared` events.
 
-### 4. Invite your bot in a channel
+### 4. Add your app to a channel
 
-Invite the bot of your Slack app in a channel, share an image and let the magic happen
+Add your app to a channel, share an image and let the magic happen:
 
 <p align="center">
   <img src="slack-textract.gif" width="50%">


### PR DESCRIPTION
It's the app that should be added to a channel, not the bot.