### PR TITLE
fix(saml-identity-provider): IdentityProvider cannot contain region information

### DIFF
--- a/src/saml-identity-provider/index.ts
+++ b/src/saml-identity-provider/index.ts
@@ -41,6 +41,7 @@ export class SamlIdentityProvider extends cdk.Construct {
 
     const arn = cdk.Stack.of(this).formatArn({
       service: 'iam',
+      region: '',
       resource: 'saml-provider',
       resourceName: name,
     });

--- a/test/saml-identity-provider/__snapshots__/saml-identity-provider.test.ts.snap
+++ b/test/saml-identity-provider/__snapshots__/saml-identity-provider.test.ts.snap
@@ -168,11 +168,7 @@ Object {
                     Object {
                       "Ref": "AWS::Partition",
                     },
-                    ":iam:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    ":iam::",
                     Object {
                       "Ref": "AWS::AccountId",
                     },


### PR DESCRIPTION
IAM is regionless.