### PR TITLE
feat(saml-identity-provider): SAML federated principal

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,6 +9,7 @@ Name|Description
 [EcsServiceRoller](#cloudstructs-ecsserviceroller)|Roll your ECS service tasks on schedule or with a rule.
 [EmailReceiver](#cloudstructs-emailreceiver)|Receive emails through SES, save them to S3 and invokes a Lambda function.
 [RollTrigger](#cloudstructs-rolltrigger)|The rule or schedule that should trigger a roll.
+[SamlFederatedPrincipal](#cloudstructs-samlfederatedprincipal)|Principal entity that represents a SAML federated identity provider.
 [SamlIdentityProvider](#cloudstructs-samlidentityprovider)|Create a SAML identity provider.
 [SlackEvents](#cloudstructs-slackevents)|Send Slack events to Amazon EventBridge.
 [SlackTextract](#cloudstructs-slacktextract)|Extract text from images posted to Slack using Amazon Textract.
@@ -233,6 +234,27 @@ static fromSchedule(schedule: Schedule): RollTrigger
 
 __Returns__:
 * <code>[RollTrigger](#cloudstructs-rolltrigger)</code>
+
+
+
+## class SamlFederatedPrincipal  <a id="cloudstructs-samlfederatedprincipal"></a>
+
+Principal entity that represents a SAML federated identity provider.
+
+__Implements__: [IPrincipal](#aws-cdk-aws-iam-iprincipal), [IGrantable](#aws-cdk-aws-iam-igrantable)
+__Extends__: [FederatedPrincipal](#aws-cdk-aws-iam-federatedprincipal)
+
+### Initializer
+
+
+
+
+```ts
+new SamlFederatedPrincipal(identityProvider: SamlIdentityProvider)
+```
+
+* **identityProvider** (<code>[SamlIdentityProvider](#cloudstructs-samlidentityprovider)</code>)  *No description*
+
 
 
 

--- a/src/saml-identity-provider/README.md
+++ b/src/saml-identity-provider/README.md
@@ -23,3 +23,12 @@ export class MyStack extends cdk.Stack {
 ```
 
 The ARN of the identity provider is exposed via the `samlIdentityProviderArn` property.
+
+Use the `SamlFederatedPrincipal` principal to create a `iam.Role` assumed by the identity
+provider:
+
+```ts
+new iam.Role(this, 'Role', {
+  assumedBy: new SamlFederatedPrincipal(identityProvider),
+})
+```

--- a/src/saml-identity-provider/index.ts
+++ b/src/saml-identity-provider/index.ts
@@ -88,3 +88,20 @@ export class SamlIdentityProvider extends cdk.Construct {
     this.samlIdentityProviderArn = idp.getResponseField('SAMLProviderArn');
   }
 }
+
+/**
+ * Principal entity that represents a SAML federated identity provider.
+ */
+export class SamlFederatedPrincipal extends iam.FederatedPrincipal {
+  constructor(identityProvider: SamlIdentityProvider) {
+    super(
+      identityProvider.samlIdentityProviderArn,
+      {
+        StringEquals: {
+          'SAML:aud': 'https://signin.aws.amazon.com/saml',
+        },
+      },
+      'sts:AssumeRoleWithSAML',
+    );
+  }
+}

--- a/test/saml-identity-provider/__snapshots__/saml-identity-provider.test.ts.snap
+++ b/test/saml-identity-provider/__snapshots__/saml-identity-provider.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EmailReceiver 1`] = `
+exports[`SamlIdentityProvider 1`] = `
 Object {
   "Parameters": Object {
     "AssetParameters4a3609ad912843e581892f37ae9d6fb0fa1648b547693aaa562b0119452b8956ArtifactHashD15A2D11": Object {
@@ -188,6 +188,33 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "Role1ABCC5F0": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRoleWithSAML",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "SAML:aud": "https://signin.aws.amazon.com/saml",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Federated": Object {
+                  "Fn::GetAtt": Array [
+                    "IdentityProviderA00909EA",
+                    "SAMLProviderArn",
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
     },
   },
 }

--- a/test/saml-identity-provider/saml-identity-provider.test.ts
+++ b/test/saml-identity-provider/saml-identity-provider.test.ts
@@ -1,15 +1,20 @@
 import * as assert from '@aws-cdk/assert';
+import * as iam from '@aws-cdk/aws-iam';
 import * as cdk from '@aws-cdk/core';
-import { SamlIdentityProvider } from '../../src';
+import { SamlFederatedPrincipal, SamlIdentityProvider } from '../../src';
 
 let stack: cdk.Stack;
 beforeEach(() => {
   stack = new cdk.Stack();
 });
 
-test('EmailReceiver', () => {
-  new SamlIdentityProvider(stack, 'IdentityProvider', {
+test('SamlIdentityProvider', () => {
+  const identityProvider = new SamlIdentityProvider(stack, 'IdentityProvider', {
     metadataDocument: '<?xml version="1.0" encoding="utf-8"?><EntityDescriptor ID="ID" entityID="ID"</EntityDescriptor>',
+  });
+
+  new iam.Role(stack, 'Role', {
+    assumedBy: new SamlFederatedPrincipal(identityProvider),
   });
 
   expect(assert.SynthUtils.toCloudFormation(stack)).toMatchSnapshot();


### PR DESCRIPTION
Add a `SamlFederatedPrincipal` to create roles assumed by the SAML identity
provider.