### PR TITLE
feat(static-website): HTTP security headers

### DIFF
--- a/API.md
+++ b/API.md
@@ -406,6 +406,7 @@ new StaticWebsite(scope: Construct, id: string, props: StaticWebsiteProps)
   * **domainName** (<code>string</code>)  The domain name for this static website. 
   * **hostedZone** (<code>[IHostedZone](#aws-cdk-aws-route53-ihostedzone)</code>)  The hosted zone where records should be added. 
   * **backendConfiguration** (<code>any</code>)  A backend configuration that will be saved as `config.json` in the S3 bucket of the static website. __*Optional*__
+  * **httpHeaders** (<code>Map<string, string></code>)  Custom HTTP headers. __*Default*__: best practice security headers
   * **redirects** (<code>Array<string></code>)  A list of domain names that should redirect to `domainName`. __*Default*__: the domain name of the hosted zone
 
 
@@ -587,6 +588,7 @@ Name | Type | Description
 **domainName** | <code>string</code> | The domain name for this static website.
 **hostedZone** | <code>[IHostedZone](#aws-cdk-aws-route53-ihostedzone)</code> | The hosted zone where records should be added.
 **backendConfiguration**? | <code>any</code> | A backend configuration that will be saved as `config.json` in the S3 bucket of the static website.<br/>__*Optional*__
+**httpHeaders**? | <code>Map<string, string></code> | Custom HTTP headers.<br/>__*Default*__: best practice security headers
 **redirects**? | <code>Array<string></code> | A list of domain names that should redirect to `domainName`.<br/>__*Default*__: the domain name of the hosted zone
 
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ High-level constructs for AWS CDK
   resources with AWS Step Functions state machines
 
 * [`StaticWebsite`](src/static-website) A CloudFront static website hosted on S3 with
-  HTTPS redirect, SPA redirect and backend configuration saved to the bucket.
+  HTTPS redirect, SPA redirect, HTTP security headers and backend configuration saved
+  to the bucket.
 
 * [`UrlShortener`](src/url-shortener) Deploy an URL shortener API

--- a/src/static-website/README.md
+++ b/src/static-website/README.md
@@ -1,7 +1,7 @@
 # StaticWebsite
 
-A CloudFront static website hosted on S3 with HTTPS redirect, SPA redirect and
-backend configuration saved to the bucket.
+A CloudFront static website hosted on S3 with HTTPS redirect, SPA redirect,
+HTTP security headers and backend configuration saved to the bucket.
 
 ## Usage
 

--- a/src/static-website/origin-response-handler/.gitignore
+++ b/src/static-website/origin-response-handler/.gitignore
@@ -1,0 +1,1 @@
+headers.json

--- a/src/static-website/origin-response-handler/index.ts
+++ b/src/static-website/origin-response-handler/index.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+let cfHeaders: AWSLambda.CloudFrontHeaders | undefined;
+
+function readHeaders() {
+  // Convert JSON headers to CF headers format
+  const headers: { [key: string]: string } = JSON.parse(fs.readFileSync(path.join(__dirname, 'headers.json'), 'utf8'));
+  cfHeaders = {};
+  for (const [key, value] of Object.entries(headers)) {
+    cfHeaders[key.toLowerCase()] = [{ key, value }];
+  }
+}
+
+
+export async function handler(event: AWSLambda.CloudFrontResponseEvent) {
+  if (!cfHeaders) {
+    readHeaders();
+  }
+
+  const { response } = event.Records[0].cf;
+
+  response.headers = { ...response.headers, ...cfHeaders };
+
+  return response;
+};

--- a/src/static-website/security-headers.ts
+++ b/src/static-website/security-headers.ts
@@ -1,0 +1,11 @@
+/**
+ * Default security headers
+ */
+export const SECURITY_HEADERS = {
+  'Strict-Transport-Security': 'max-age=31536000; includeSubdomains; preload',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'X-XSS-Protection': '1; mode=block',
+  'Referrer-Policy': 'same-origin',
+  'Content-Security-Policy': "default-src 'self'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; require-trusted-types-for 'script';",
+};

--- a/test/static-website/__snapshots__/static-website.test.ts.snap
+++ b/test/static-website/__snapshots__/static-website.test.ts.snap
@@ -3,6 +3,18 @@
 exports[`StaticWebsite 1`] = `
 Object {
   "Parameters": Object {
+    "AssetParameters03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1ArtifactHashE33B1DF7": Object {
+      "Description": "Artifact hash for asset \\"03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1\\"",
+      "Type": "String",
+    },
+    "AssetParameters03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1S3Bucket42FC57A4": Object {
+      "Description": "S3 bucket for asset \\"03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1\\"",
+      "Type": "String",
+    },
+    "AssetParameters03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1S3VersionKey184679B4": Object {
+      "Description": "S3 key for asset version \\"03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1\\"",
+      "Type": "String",
+    },
     "AssetParameters4c5f927959e8f372b3efeb876320509126f376a0acf53c36e668e7656dcf26e9ArtifactHashE87B5926": Object {
       "Description": "Artifact hash for asset \\"4c5f927959e8f372b3efeb876320509126f376a0acf53c36e668e7656dcf26e9\\"",
       "Type": "String",
@@ -90,6 +102,116 @@ Object {
       "Type": "AWS::SSM::Parameter",
     },
     "OriginRequestServiceRole04760C2E": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "edgelambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "OriginResponse488DDAA0": Object {
+      "DependsOn": Array [
+        "OriginResponseServiceRoleD33C7FC6",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Ref": "AssetParameters03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1S3Bucket42FC57A4",
+          },
+          "S3Key": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                Object {
+                  "Fn::Select": Array [
+                    0,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1S3VersionKey184679B4",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Fn::Select": Array [
+                    1,
+                    Object {
+                      "Fn::Split": Array [
+                        "||",
+                        Object {
+                          "Ref": "AssetParameters03d5e7941ac4bbdef3a2bafb700192fa65e7500b58b5764dae3be5b99c9503f1S3VersionKey184679B4",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "OriginResponseServiceRoleD33C7FC6",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs12.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "OriginResponseCurrentVersion9FB3D014a3e658cd5fb866f036ac3e89a9cf5492": Object {
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "OriginResponse488DDAA0",
+        },
+      },
+      "Type": "AWS::Lambda::Version",
+    },
+    "OriginResponseParameter7A7C8B4F": Object {
+      "Properties": Object {
+        "Name": "EdgeFunctionArnOriginResponse",
+        "Type": "String",
+        "Value": Object {
+          "Ref": "OriginResponseCurrentVersion9FB3D014a3e658cd5fb866f036ac3e89a9cf5492",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "OriginResponseServiceRoleD33C7FC6": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -811,6 +933,15 @@ Object {
                   ],
                 },
               },
+              Object {
+                "EventType": "origin-response",
+                "LambdaFunctionARN": Object {
+                  "Fn::GetAtt": Array [
+                    "StaticWebsiteOriginResponseArnReader75C7EB4A",
+                    "FunctionArn",
+                  ],
+                },
+              },
             ],
             "TargetOriginId": "StackStaticWebsiteDistributionOrigin103625211",
             "ViewerProtocolPolicy": "redirect-to-https",
@@ -1177,6 +1308,22 @@ Object {
       "Properties": Object {
         "ParameterName": "EdgeFunctionArnOriginRequest",
         "RefreshToken": "6222ca73684368aae6489450bc8ad991",
+        "Region": "us-east-1",
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCrossRegionStringParameterReaderCustomResourceProviderHandler65B5F33A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::CrossRegionStringParameterReader",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "StaticWebsiteOriginResponseArnReader75C7EB4A": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "ParameterName": "EdgeFunctionArnOriginResponse",
+        "RefreshToken": "9300b2764ecbcb3a5d699804daca1eef",
         "Region": "us-east-1",
         "ServiceToken": Object {
           "Fn::GetAtt": Array [

--- a/test/static-website/origin-request-handler.test.ts
+++ b/test/static-website/origin-request-handler.test.ts
@@ -1,0 +1,33 @@
+import { handler } from '../../src/static-website/origin-request-handler';
+
+test('without extension', async () => {
+  const request = await handler({
+    Records: [
+      {
+        cf: {
+          request: {
+            uri: '/my-uri',
+          },
+        },
+      },
+    ],
+  } as AWSLambda.CloudFrontRequestEvent);
+
+  expect(request.uri).toBe('/index.html');
+});
+
+test('with extension', async () => {
+  const request = await handler({
+    Records: [
+      {
+        cf: {
+          request: {
+            uri: '/style/cool.css',
+          },
+        },
+      },
+    ],
+  } as AWSLambda.CloudFrontRequestEvent);
+
+  expect(request.uri).toBe('/style/cool.css');
+});

--- a/test/static-website/origin-response-handler.test.ts
+++ b/test/static-website/origin-response-handler.test.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { handler } from '../../src/static-website/origin-response-handler';
+
+const headersJsonPath = path.join(__dirname, '../../src/static-website/origin-response-handler', 'headers.json');
+
+afterEach(() => {
+  if (fs.existsSync(headersJsonPath)) {
+    fs.unlinkSync(headersJsonPath);
+  }
+});
+
+test('adds headers', async () => {
+  fs.writeFileSync(path.join(headersJsonPath), JSON.stringify({
+    'X-Frame-Options': 'DENY',
+  }));
+
+  const response = await handler({
+    Records: [
+      {
+        cf: {
+          response: {
+            headers: {
+              'content-type': [{ key: 'Content-Type', value: 'text/html' }],
+            },
+          },
+        },
+      },
+    ],
+  } as unknown as AWSLambda.CloudFrontResponseEvent);
+
+  expect(response.headers).toEqual({
+    'content-type': [{ key: 'Content-Type', value: 'text/html' }],
+    'x-frame-options': [{ key: 'X-Frame-Options', value: 'DENY' }],
+  });
+});


### PR DESCRIPTION
Add HTTP security headers with an origin response `Lambda@Edge` function.

Also add a `httpHeaders` prop to customize HTTP headers.