### PR TITLE
fix(url-shortener): redirect object is not publicly accessible

### DIFF
--- a/src/url-shortener/index.handler.ts
+++ b/src/url-shortener/index.handler.ts
@@ -63,6 +63,7 @@ export async function handler(event: AWSLambda.APIGatewayProxyEvent): Promise<AW
       Bucket: getEnv('BUCKET_NAME'),
       Key: key,
       WebsiteRedirectLocation: body.url,
+      ACL: 'public-read',
     }).promise();
     console.log('Put object: %j', putObject);
 

--- a/test/url-shortener/__snapshots__/url-shortener.test.ts.snap
+++ b/test/url-shortener/__snapshots__/url-shortener.test.ts.snap
@@ -41,18 +41,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68ArtifactHashB22F10D6": Object {
-      "Description": "Artifact hash for asset \\"13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68\\"",
-      "Type": "String",
-    },
-    "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3Bucket0F9C6CA8": Object {
-      "Description": "S3 bucket for asset \\"13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68\\"",
-      "Type": "String",
-    },
-    "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3VersionKey64354510": Object {
-      "Description": "S3 key for asset version \\"13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -75,6 +63,18 @@ Object {
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4S3VersionKey326451BC": Object {
       "Description": "S3 key for asset version \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
+      "Type": "String",
+    },
+    "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76ArtifactHashFF2D3654": Object {
+      "Description": "Artifact hash for asset \\"a907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76\\"",
+      "Type": "String",
+    },
+    "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3Bucket3C884982": Object {
+      "Description": "S3 bucket for asset \\"a907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76\\"",
+      "Type": "String",
+    },
+    "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3VersionKey014BC81C": Object {
+      "Description": "S3 key for asset version \\"a907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76\\"",
       "Type": "String",
     },
   },
@@ -839,7 +839,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3Bucket0F9C6CA8",
+            "Ref": "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3Bucket3C884982",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -852,7 +852,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3VersionKey64354510",
+                          "Ref": "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3VersionKey014BC81C",
                         },
                       ],
                     },
@@ -865,7 +865,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3VersionKey64354510",
+                          "Ref": "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3VersionKey014BC81C",
                         },
                       ],
                     },
@@ -1049,18 +1049,6 @@ Object {
     },
   },
   "Parameters": Object {
-    "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68ArtifactHashB22F10D6": Object {
-      "Description": "Artifact hash for asset \\"13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68\\"",
-      "Type": "String",
-    },
-    "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3Bucket0F9C6CA8": Object {
-      "Description": "S3 bucket for asset \\"13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68\\"",
-      "Type": "String",
-    },
-    "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3VersionKey64354510": Object {
-      "Description": "S3 key for asset version \\"13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68\\"",
-      "Type": "String",
-    },
     "AssetParameters67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24ArtifactHashBA91B77F": Object {
       "Description": "Artifact hash for asset \\"67b7823b74bc135986aa72f889d6a8da058d0c4a20cbc2dfc6f78995fdd2fc24\\"",
       "Type": "String",
@@ -1083,6 +1071,18 @@ Object {
     },
     "AssetParameters7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4S3VersionKey326451BC": Object {
       "Description": "S3 key for asset version \\"7af6295e521fd55af94332393ceffb3e866aac4dc4956321f7918f21e72199e4\\"",
+      "Type": "String",
+    },
+    "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76ArtifactHashFF2D3654": Object {
+      "Description": "Artifact hash for asset \\"a907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76\\"",
+      "Type": "String",
+    },
+    "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3Bucket3C884982": Object {
+      "Description": "S3 bucket for asset \\"a907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76\\"",
+      "Type": "String",
+    },
+    "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3VersionKey014BC81C": Object {
+      "Description": "S3 key for asset version \\"a907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76\\"",
       "Type": "String",
     },
   },
@@ -1954,7 +1954,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3Bucket0F9C6CA8",
+            "Ref": "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3Bucket3C884982",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -1967,7 +1967,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3VersionKey64354510",
+                          "Ref": "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3VersionKey014BC81C",
                         },
                       ],
                     },
@@ -1980,7 +1980,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters13c7be5968aaa8d690ddce1a9459fb41c886d509864bbbc4a91f4451adbe0c68S3VersionKey64354510",
+                          "Ref": "AssetParametersa907b877170e3ecf438182c3a216d7c8e5e563c6a1a415359f4ea1d3fb1ede76S3VersionKey014BC81C",
                         },
                       ],
                     },

--- a/test/url-shortener/handler.test.ts
+++ b/test/url-shortener/handler.test.ts
@@ -53,6 +53,7 @@ test('returns 201 with short url', async () => {
   });
 
   expect(s3ClientMock.putObject).toHaveBeenCalledWith({
+    ACL: 'public-read',
     Bucket: 'bucket',
     Key: 'QI',
     WebsiteRedirectLocation: 'https://www.url.com/very/long',


### PR DESCRIPTION
Make the redirect object publicly accessible when uploading
by setting the ACL to `public-read`.