### PR TITLE
chore(toolkit-cleaner): fix README typo

### DIFF
--- a/src/toolkit-cleaner/README.md
+++ b/src/toolkit-cleaner/README.md
@@ -15,7 +15,7 @@ export class MyStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    new ToolkitCleaner(this, 'ToolkitCleaner');
+    new cloudstructs.ToolkitCleaner(this, 'ToolkitCleaner');
   }
 }
 ```


### PR DESCRIPTION
Fix [README](https://github.com/jogold/cloudstructs/blob/master/src/toolkit-cleaner/README.md) typo.
```ts
    new ToolkitCleaner(this, 'ToolkitCleaner');
```
to 
```ts
    new cloudstructs.ToolkitCleaner(this, 'ToolkitCleaner');
```