### PR TITLE
feat(toolkit-cleaner): allow only manual runs

### DIFF
--- a/API.md
+++ b/API.md
@@ -650,6 +650,7 @@ new ToolkitCleaner(scope: Construct, id: string, props?: ToolkitCleanerProps)
   * **dryRun** (<code>boolean</code>)  Only output number of assets and total size that would be deleted but without actually deleting assets. __*Optional*__
   * **retainAssetsNewerThan** (<code>[Duration](#aws-cdk-lib-duration)</code>)  Retain unused assets that were created recently. __*Default*__: all unused assets are removed
   * **schedule** (<code>[aws_events.Schedule](#aws-cdk-lib-aws-events-schedule)</code>)  The schedule for the cleaner. __*Default*__: every day
+  * **scheduleEnabled** (<code>boolean</code>)  Whether to clean on schedule. __*Default*__: true
 
 
 
@@ -1021,6 +1022,7 @@ Name | Type | Description
 **dryRun**? | <code>boolean</code> | Only output number of assets and total size that would be deleted but without actually deleting assets.<br/>__*Optional*__
 **retainAssetsNewerThan**? | <code>[Duration](#aws-cdk-lib-duration)</code> | Retain unused assets that were created recently.<br/>__*Default*__: all unused assets are removed
 **schedule**? | <code>[aws_events.Schedule](#aws-cdk-lib-aws-events-schedule)</code> | The schedule for the cleaner.<br/>__*Default*__: every day
+**scheduleEnabled**? | <code>boolean</code> | Whether to clean on schedule.<br/>__*Default*__: true
 
 
 

--- a/src/toolkit-cleaner/README.md
+++ b/src/toolkit-cleaner/README.md
@@ -24,7 +24,9 @@ The `ToolkitCleaner` construct creates a state machine that runs every day
 and removes unused S3 and ECR assets from your CDK Toolkit. The state machine
 outputs the number of deleted assets and the total reclaimed size in bytes.
 
-The running frequency can be customized using the `schedule` prop.
+The running frequency can be customized using the `schedule` prop. You can also
+choose to only run the Step Function manually by passing
+`scheduleEnabled: false`.
 
 By default all unused assets are removed. If you wish to retain assets that
 were created recently, specify the `retainAssetsNewerThan` prop:

--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -17,11 +17,19 @@ import { GetStackNamesFunction } from './get-stack-names-function';
  */
 export interface ToolkitCleanerProps {
   /**
-   * The schedule for the cleaner
+   * The schedule for the cleaner.
    *
    * @default - every day
    */
   readonly schedule?: Schedule;
+
+  /**
+   * Is the schedule active? If you'd like to run the cleanup manually via the
+   * UI, set to `false`.
+   *
+   * @default - true
+   */
+  readonly scheduleEnabled?: boolean;
 
   /**
    * Only output number of assets and total size that would be deleted
@@ -132,6 +140,7 @@ export class ToolkitCleaner extends Construct {
     });
 
     const rule = new Rule(this, 'Rule', {
+      enabled: props.scheduleEnabled ?? true,
       schedule: props.schedule ?? Schedule.rate(Duration.days(1)),
     });
     rule.addTarget(new SfnStateMachine(stateMachine));

--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -24,7 +24,7 @@ export interface ToolkitCleanerProps {
   readonly schedule?: Schedule;
 
   /**
-   * Whether to clean on schedule. If you'd like to run the cleanup manually 
+   * Whether to clean on schedule. If you'd like to run the cleanup manually
    * via the console, set to `false`.
    *
    * @default true

--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -24,10 +24,10 @@ export interface ToolkitCleanerProps {
   readonly schedule?: Schedule;
 
   /**
-   * Is the schedule active? If you'd like to run the cleanup manually via the
-   * UI, set to `false`.
+   * Whether to clean on schedule. If you'd like to run the cleanup manually 
+   * via the console, set to `false`.
    *
-   * @default - true
+   * @default true
    */
   readonly scheduleEnabled?: boolean;
 


### PR DESCRIPTION
Thank you for writing this toolkit clean-up logic. It's a great solution & I'd love to see it integration into the core CDK project at some point. This will really help out several of my larger clients that rely heavily on CDK.

In the meantime, I tested this out against my personal stacks and it worked flawlessly. However, I'd like to be able to only run it manually (e.g., not on a schedule) for this account. This PR adds the ability to pass `schedule: null`, which skips creating the eventbridge rule.