### PR TITLE
fix(toolkit-cleaner): used S3 assets could be deleted

### DIFF
--- a/src/toolkit-cleaner/clean-objects.lambda.ts
+++ b/src/toolkit-cleaner/clean-objects.lambda.ts
@@ -25,11 +25,15 @@ export async function handler(assetHashes: string[]) {
       }
 
       const hash = path.basename(x.Key, path.extname(x.Key));
-      let pred: boolean | undefined = !assetHashes.includes(hash);
+      let pred = !assetHashes.includes(hash);
 
       if (process.env.RETAIN_MILLISECONDS) {
+        if (!x.LastModified) {
+          return false;
+        }
+
         const limitDate = new Date(Date.now() - parseInt(process.env.RETAIN_MILLISECONDS));
-        pred = pred && x.LastModified && x.LastModified < limitDate;
+        pred = pred && x.LastModified < limitDate;
       }
 
       return pred;

--- a/src/toolkit-cleaner/clean-objects.lambda.ts
+++ b/src/toolkit-cleaner/clean-objects.lambda.ts
@@ -20,11 +20,18 @@ export async function handler(assetHashes: string[]) {
     }).promise();
 
     const toDelete = response.Contents?.filter(x => {
-      let pred = x.Key && !assetHashes.includes(path.basename(x.Key));
+      if (!x.Key) {
+        return false;
+      }
+
+      const hash = path.basename(x.Key, path.extname(x.Key));
+      let pred: boolean | undefined = !assetHashes.includes(hash);
+
       if (process.env.RETAIN_MILLISECONDS) {
         const limitDate = new Date(Date.now() - parseInt(process.env.RETAIN_MILLISECONDS));
         pred = pred && x.LastModified && x.LastModified < limitDate;
       }
+
       return pred;
     });
 

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
@@ -53,15 +53,15 @@
         }
       }
     },
-    "57e2e5c5b8d354c6b7ad1154ad368556fb4a414f510da682550f5d9233904e0b": {
+    "898de87125fffb763a27513f4459153fd91d0382b071cdb7bd1d4e965eea278a": {
       "source": {
-        "path": "asset.57e2e5c5b8d354c6b7ad1154ad368556fb4a414f510da682550f5d9233904e0b.lambda",
+        "path": "asset.898de87125fffb763a27513f4459153fd91d0382b071cdb7bd1d4e965eea278a.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "57e2e5c5b8d354c6b7ad1154ad368556fb4a414f510da682550f5d9233904e0b.zip",
+          "objectKey": "898de87125fffb763a27513f4459153fd91d0382b071cdb7bd1d4e965eea278a.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -79,7 +79,7 @@
         }
       }
     },
-    "4153c1fd12588c570ec04acd027344bdcf5d1379cefdada91f29a4a518ac0c90": {
+    "695997417aeb8fd95040a1d5aeb744e1de17dcb01b7de947e04988529e6f266e": {
       "source": {
         "path": "toolkit-cleaner-integ.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4153c1fd12588c570ec04acd027344bdcf5d1379cefdada91f29a4a518ac0c90.json",
+          "objectKey": "695997417aeb8fd95040a1d5aeb744e1de17dcb01b7de947e04988529e6f266e.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
@@ -53,15 +53,15 @@
         }
       }
     },
-    "fe501c8a9ff2f57bc589a7b9667a17340389a3c541e65b0d4a7fcb23c734cf8b": {
+    "57e2e5c5b8d354c6b7ad1154ad368556fb4a414f510da682550f5d9233904e0b": {
       "source": {
-        "path": "asset.fe501c8a9ff2f57bc589a7b9667a17340389a3c541e65b0d4a7fcb23c734cf8b.lambda",
+        "path": "asset.57e2e5c5b8d354c6b7ad1154ad368556fb4a414f510da682550f5d9233904e0b.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "fe501c8a9ff2f57bc589a7b9667a17340389a3c541e65b0d4a7fcb23c734cf8b.zip",
+          "objectKey": "57e2e5c5b8d354c6b7ad1154ad368556fb4a414f510da682550f5d9233904e0b.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -79,7 +79,7 @@
         }
       }
     },
-    "d0304adc2e55a043027ce3ec87031194051799adafebfd0a967581b54d6d9e5a": {
+    "4153c1fd12588c570ec04acd027344bdcf5d1379cefdada91f29a4a518ac0c90": {
       "source": {
         "path": "toolkit-cleaner-integ.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d0304adc2e55a043027ce3ec87031194051799adafebfd0a967581b54d6d9e5a.json",
+          "objectKey": "4153c1fd12588c570ec04acd027344bdcf5d1379cefdada91f29a4a518ac0c90.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
@@ -278,7 +278,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "57e2e5c5b8d354c6b7ad1154ad368556fb4a414f510da682550f5d9233904e0b.zip"
+          "S3Key": "898de87125fffb763a27513f4459153fd91d0382b071cdb7bd1d4e965eea278a.zip"
         },
         "Role": {
           "Fn::GetAtt": [

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
@@ -278,7 +278,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "fe501c8a9ff2f57bc589a7b9667a17340389a3c541e65b0d4a7fcb23c734cf8b.zip"
+          "S3Key": "57e2e5c5b8d354c6b7ad1154ad368556fb4a414f510da682550f5d9233904e0b.zip"
         },
         "Role": {
           "Fn::GetAtt": [


### PR DESCRIPTION
This was due to an incorrect comparison with the file extension.