### PR TITLE
fix(toolkit-cleaner): listing stacks can timeout

### DIFF
--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -61,7 +61,9 @@ export class ToolkitCleaner extends Construct {
       directory: path.join(__dirname, '..', '..', 'assets', 'toolkit-cleaner', 'docker'),
     });
 
-    const getStackNamesFunction = new GetStackNamesFunction(this, 'GetStackNamesFunction');
+    const getStackNamesFunction = new GetStackNamesFunction(this, 'GetStackNamesFunction', {
+      timeout: Duration.seconds(30),
+    });
     getStackNamesFunction.addToRolePolicy(new PolicyStatement({
       actions: ['cloudformation:DescribeStacks'],
       resources: ['*'],

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
@@ -79,7 +79,7 @@
         }
       }
     },
-    "4bd7b3aef7383a38ea2d82f56cf5f20692f3c44a7dd580904bcd2467a93a6e00": {
+    "db61841f8cf7dc425cb3cdcac77f5689a6fcfae4c7be9be0876df90c5c83052e": {
       "source": {
         "path": "toolkit-cleaner-integ.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4bd7b3aef7383a38ea2d82f56cf5f20692f3c44a7dd580904bcd2467a93a6e00.json",
+          "objectKey": "db61841f8cf7dc425cb3cdcac77f5689a6fcfae4c7be9be0876df90c5c83052e.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
@@ -74,7 +74,8 @@
           }
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs16.x"
+        "Runtime": "nodejs16.x",
+        "Timeout": 30
       },
       "DependsOn": [
         "ToolkitCleanerGetStackNamesFunctionServiceRoleDefaultPolicy8FBA731D",


### PR DESCRIPTION
On accounts with large amounts of stacks, 3 seconds is not enough
to list all stacks. 30 seconds should be more than enough to tackle 
even the largest sets of stacks.