### PR TITLE
fix(toolkit-cleaner): docker images with prefixed tags are always deleted

### DIFF
--- a/src/toolkit-cleaner/extract-template-hashes.lambda.ts
+++ b/src/toolkit-cleaner/extract-template-hashes.lambda.ts
@@ -27,5 +27,5 @@ function findDockerTagPrefix(hash: string): string {
     return '';
   }
 
-  return hash.substring(0, hash.length - 64)
+  return hash.substring(0, hash.length - 64);
 }

--- a/src/toolkit-cleaner/extract-template-hashes.lambda.ts
+++ b/src/toolkit-cleaner/extract-template-hashes.lambda.ts
@@ -11,7 +11,21 @@ export async function handler(stackName: string) {
     return [];
   }
 
-  const hashes = template.TemplateBody.match(/[a-f0-9]{64}/g);
+  if (!process.env.DOCKER_IMAGE_ASSET_HASH) {
+    throw new Error('Missing DOCKER_IMAGE_ASSET_HASH environment variable');
+  }
+  const dockerTagPrefix = findDockerTagPrefix(process.env.DOCKER_IMAGE_ASSET_HASH);
+
+  const regexp = new RegExp(`(${dockerTagPrefix})?[a-f0-9]{64}`, 'g');
+  const hashes = template.TemplateBody.match(regexp);
 
   return [...new Set(hashes)];
+}
+
+function findDockerTagPrefix(hash: string): string {
+  if (hash.length === 64) {
+    return '';
+  }
+
+  return hash.substring(0, hash.length - 64)
 }

--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -84,7 +84,7 @@ export class ToolkitCleaner extends Construct {
       timeout: Duration.seconds(30),
       environment: {
         DOCKER_IMAGE_ASSET_HASH: dockerImageAsset.assetHash,
-      }
+      },
     });
     extractTemplateHashesFunction.addToRolePolicy(new PolicyStatement({
       actions: ['cloudformation:GetTemplate'],

--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -82,6 +82,9 @@ export class ToolkitCleaner extends Construct {
 
     const extractTemplateHashesFunction = new ExtractTemplateHashesFunction(this, 'ExtractTemplateHashesFunction', {
       timeout: Duration.seconds(30),
+      environment: {
+        DOCKER_IMAGE_ASSET_HASH: dockerImageAsset.assetHash,
+      }
     });
     extractTemplateHashesFunction.addToRolePolicy(new PolicyStatement({
       actions: ['cloudformation:GetTemplate'],

--- a/test/toolkit-cleaner/extract-template-hashes.test.ts
+++ b/test/toolkit-cleaner/extract-template-hashes.test.ts
@@ -4,11 +4,13 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { handler } from '../../src/toolkit-cleaner/extract-template-hashes.lambda';
 
 const cloudFormationClientMock = mockClient(CloudFormationClient);
-cloudFormationClientMock.on(GetTemplateCommand).resolves({
-  TemplateBody: 'hello 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 world 486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7',
-});
 
 test('extracts hashes', async () => {
+  process.env.DOCKER_IMAGE_ASSET_HASH = '5a7abf30ce10141adcb73c9b836ec68479c65fb4d1693df160563e36ece0d55e';
+
+  cloudFormationClientMock.on(GetTemplateCommand).resolves({
+    TemplateBody: 'hello 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 world 486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7',
+  });
 
   const response = await handler('stack1');
 
@@ -16,6 +18,23 @@ test('extracts hashes', async () => {
 
   expect(response).toEqual([
     '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    '486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7',
+  ]);
+});
+
+test('extracts hashes with docker tag prefix', async () => {
+  process.env.DOCKER_IMAGE_ASSET_HASH = 'prefix5a7abf30ce10141adcb73c9b836ec68479c65fb4d1693df160563e36ece0d55e';
+
+  cloudFormationClientMock.on(GetTemplateCommand).resolves({
+    TemplateBody: 'hello prefix2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 world 486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7',
+  });
+
+  const response = await handler('stack1');
+
+  expect(cloudFormationClientMock).toHaveReceivedCommandWith(GetTemplateCommand, { StackName: 'stack1' });
+
+  expect(response).toEqual([
+    'prefix2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
     '486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7',
   ]);
 });

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
@@ -27,15 +27,15 @@
         }
       }
     },
-    "e2fc900c4989c9292d92789a3c86dc4c928e649bf168c2547f48b503dd41a520": {
+    "839231c3a66de2124ed53cba376ac7d09e962b10a04d77f96cd2f74e930f75c9": {
       "source": {
-        "path": "asset.e2fc900c4989c9292d92789a3c86dc4c928e649bf168c2547f48b503dd41a520.lambda",
+        "path": "asset.839231c3a66de2124ed53cba376ac7d09e962b10a04d77f96cd2f74e930f75c9.lambda",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e2fc900c4989c9292d92789a3c86dc4c928e649bf168c2547f48b503dd41a520.zip",
+          "objectKey": "839231c3a66de2124ed53cba376ac7d09e962b10a04d77f96cd2f74e930f75c9.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -79,7 +79,7 @@
         }
       }
     },
-    "14fd8c2a54dd634868c0496f806f1d30d38056ee29131403ae4e4166ed615812": {
+    "98fffe1b2edbf8c7f26bc9d9b99a394ae270f6137796d379c74d08efc690cabb": {
       "source": {
         "path": "toolkit-cleaner-integ.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "14fd8c2a54dd634868c0496f806f1d30d38056ee29131403ae4e4166ed615812.json",
+          "objectKey": "98fffe1b2edbf8c7f26bc9d9b99a394ae270f6137796d379c74d08efc690cabb.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
@@ -144,7 +144,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "e2fc900c4989c9292d92789a3c86dc4c928e649bf168c2547f48b503dd41a520.zip"
+          "S3Key": "839231c3a66de2124ed53cba376ac7d09e962b10a04d77f96cd2f74e930f75c9.zip"
         },
         "Role": {
           "Fn::GetAtt": [
@@ -155,6 +155,7 @@
         "Description": "src/toolkit-cleaner/extract-template-hashes.lambda.ts",
         "Environment": {
           "Variables": {
+            "DOCKER_IMAGE_ASSET_HASH": "59bc252bbfc4819edcc48f546a0ea71b7b108d3899f8f503cd6f5bcc1f375126",
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
           }
         },


### PR DESCRIPTION
Use the hash of the dummy docker image to determine if 
there is a prefix.

Fixes #246