### PR TITLE
fix(toolkit-cleaner): construct is using deprecated API

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -167,7 +167,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.112.0",
+      "version": "^2.133.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -6,7 +6,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   authorName: 'Jonathan Goldwasser',
   description: 'High-level constructs for AWS CDK',
   jsiiVersion: '5.x',
-  cdkVersion: '2.112.0',
+  cdkVersion: '2.133.0',
   name: 'cloudstructs',
   repository: 'https://github.com/jogold/cloudstructs.git',
   peerDeps: [],

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
     "aws-cdk": "^2",
-    "aws-cdk-lib": "2.112.0",
+    "aws-cdk-lib": "2.133.0",
     "aws-sdk-client-mock": "^2.2.0",
     "aws-sdk-client-mock-jest": "^2.2.0",
     "constructs": "10.0.5",
@@ -129,7 +129,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.112.0",
+    "aws-cdk-lib": "^2.133.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -140,7 +140,7 @@ export class ToolkitCleaner extends Construct {
     const stateMachine = new sfn.StateMachine(this, 'Resource', {
       definitionBody: sfn.DefinitionBody.fromChainable(
         getStackNames
-          .next(stacksMap.iterator(extractTemplateHashes))
+          .next(stacksMap.itemProcessor(extractTemplateHashes))
           .next(flattenHashes)
           .next(new sfn.Parallel(this, 'Clean')
             .branch(cleanObjects)

--- a/test/codecommit-mirror/__snapshots__/codecommit-mirror.test.ts.snap
+++ b/test/codecommit-mirror/__snapshots__/codecommit-mirror.test.ts.snap
@@ -608,6 +608,26 @@ exports[`CodeCommitMirror with a private GitHub repo 1`] = `
               },
             },
             {
+              "Action": "ecs:TagResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ecs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":*:task/",
+                    {
+                      "Ref": "ClusterEB0386A7",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
               "Action": "iam:PassRole",
               "Effect": "Allow",
               "Resource": {
@@ -1422,6 +1442,26 @@ exports[`CodeCommitMirror with a public GitHub repo 1`] = `
               "Effect": "Allow",
               "Resource": {
                 "Ref": "MirrorTaskDefinitionBBDEF66A",
+              },
+            },
+            {
+              "Action": "ecs:TagResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ecs:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":*:task/",
+                    {
+                      "Ref": "ClusterEB0386A7",
+                    },
+                    "/*",
+                  ],
+                ],
               },
             },
             {

--- a/test/ecs-service-roller/__snapshots__/ecs-service-roller.test.ts.snap
+++ b/test/ecs-service-roller/__snapshots__/ecs-service-roller.test.ts.snap
@@ -20,7 +20,7 @@ exports[`EcsServiceRoller with default 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5626dac41d5e2eaf12db03451d44d017deffa332358cd3f142412754402ef7c.zip",
+          "S3Key": "f917396796eb3f83098f0ef32e3d38a0d75ddece58d94ad9ddffa5cf720d4805.zip",
         },
         "Handler": "index.handler",
         "MemorySize": 256,
@@ -724,7 +724,7 @@ exports[`EcsServiceRoller with rule 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5626dac41d5e2eaf12db03451d44d017deffa332358cd3f142412754402ef7c.zip",
+          "S3Key": "f917396796eb3f83098f0ef32e3d38a0d75ddece58d94ad9ddffa5cf720d4805.zip",
         },
         "Handler": "index.handler",
         "MemorySize": 256,
@@ -1432,7 +1432,7 @@ exports[`EcsServiceRoller with schedule 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "d5626dac41d5e2eaf12db03451d44d017deffa332358cd3f142412754402ef7c.zip",
+          "S3Key": "f917396796eb3f83098f0ef32e3d38a0d75ddece58d94ad9ddffa5cf720d4805.zip",
         },
         "Handler": "index.handler",
         "MemorySize": 256,

--- a/test/saml-identity-provider/__snapshots__/saml-identity-provider.test.ts.snap
+++ b/test/saml-identity-provider/__snapshots__/saml-identity-provider.test.ts.snap
@@ -19,7 +19,7 @@ exports[`SamlIdentityProvider 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "17c16a3854838fd3ff4bda08146122a6701f33b9c86ae17f415ad0dc47a97544.zip",
+          "S3Key": "cb92a348b5b60bcbbe3888108f15e75877121eb402b4a74526927300fcc54975.zip",
         },
         "Handler": "index.handler",
         "Role": {

--- a/test/slack-app/__snapshots__/slack-app.test.ts.snap
+++ b/test/slack-app/__snapshots__/slack-app.test.ts.snap
@@ -145,7 +145,7 @@ exports[`SlackApp 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
+          "S3Key": "3542be390685e0c8353d92ccb5796d343cd93ca946b6b0de798004206a199adc.zip",
         },
         "Description": "AWS CDK resource provider framework - onEvent (Default/SlackAppProvider/Resource)",
         "Environment": {

--- a/test/slack-app/slack-app.integ.snapshot/slack-app-integ.assets.json
+++ b/test/slack-app/slack-app.integ.snapshot/slack-app-integ.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "35.0.0",
+  "version": "36.0.0",
   "files": {
     "ada9251e2af3daf198f52f17e3371cb1a7b8ab4b280eea60518707204911cb61": {
       "source": {
@@ -27,20 +27,20 @@
         }
       }
     },
-    "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94": {
+    "3542be390685e0c8353d92ccb5796d343cd93ca946b6b0de798004206a199adc": {
       "source": {
-        "path": "asset.7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94",
+        "path": "asset.3542be390685e0c8353d92ccb5796d343cd93ca946b6b0de798004206a199adc",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip",
+          "objectKey": "3542be390685e0c8353d92ccb5796d343cd93ca946b6b0de798004206a199adc.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "72ff6fedcb1cc61d8db1c3d09860e1eb1026b801fc55b015028f951a7b97b1b6": {
+    "5e97e0c46d6a7dbfb6cf0f30788809ccaaa60f3cb27d263de0318d466556c92b": {
       "source": {
         "path": "slack-app-integ.template.json",
         "packaging": "file"
@@ -48,7 +48,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "72ff6fedcb1cc61d8db1c3d09860e1eb1026b801fc55b015028f951a7b97b1b6.json",
+          "objectKey": "5e97e0c46d6a7dbfb6cf0f30788809ccaaa60f3cb27d263de0318d466556c92b.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/slack-app/slack-app.integ.snapshot/slack-app-integ.template.json
+++ b/test/slack-app/slack-app.integ.snapshot/slack-app-integ.template.json
@@ -289,7 +289,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "7382a0addb9f34974a1ea6c6c9b063882af874828f366f5c93b2b7b64db15c94.zip"
+     "S3Key": "3542be390685e0c8353d92ccb5796d343cd93ca946b6b0de798004206a199adc.zip"
     },
     "Description": "AWS CDK resource provider framework - onEvent (slack-app-integ/SlackAppProvider/Resource)",
     "Environment": {

--- a/test/ssl-server-test/ssl-server-test.integ.snapshot/ssl-server-test-integ.assets.json
+++ b/test/ssl-server-test/ssl-server-test.integ.snapshot/ssl-server-test-integ.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "35.0.0",
+  "version": "36.0.0",
   "files": {
     "9db120688461d865c813bd640672ebde6708d8dd687df3a95923ad04d9c097c1": {
       "source": {

--- a/test/static-website/__snapshots__/static-website.test.ts.snap
+++ b/test/static-website/__snapshots__/static-website.test.ts.snap
@@ -149,7 +149,7 @@ exports[`StaticWebsite 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "17c16a3854838fd3ff4bda08146122a6701f33b9c86ae17f415ad0dc47a97544.zip",
+          "S3Key": "cb92a348b5b60bcbbe3888108f15e75877121eb402b4a74526927300fcc54975.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -290,7 +290,7 @@ exports[`StaticWebsite 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip",
+          "S3Key": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "35.0.0",
+  "version": "36.0.0",
   "files": {
     "95c924c84f5d023be4edee540cb2cb401a49f115d01ed403b288f6cb412771df": {
       "source": {
@@ -79,7 +79,7 @@
         }
       }
     },
-    "98847dde48fcfdf640649e0b6d6475dfbb32da6bf54a09507e02cb06c4fd11a8": {
+    "92f9cadfef0d55746244db5e99b1dedebf3f3423d3363b7ba6d201890151114a": {
       "source": {
         "path": "toolkit-cleaner-integ.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "98847dde48fcfdf640649e0b6d6475dfbb32da6bf54a09507e02cb06c4fd11a8.json",
+          "objectKey": "92f9cadfef0d55746244db5e99b1dedebf3f3423d3363b7ba6d201890151114a.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
@@ -606,7 +606,7 @@
          "Arn"
         ]
        },
-       "\"},\"StacksMap\":{\"Type\":\"Map\",\"Next\":\"FlattenHashes\",\"ResultSelector\":{\"AssetHashes.$\":\"$\"},\"Iterator\":{\"StartAt\":\"ExtractTemplateHashes\",\"States\":{\"ExtractTemplateHashes\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Throttling\"]}],\"Type\":\"Task\",\"Resource\":\"",
+       "\"},\"StacksMap\":{\"Type\":\"Map\",\"Next\":\"FlattenHashes\",\"ResultSelector\":{\"AssetHashes.$\":\"$\"},\"ItemProcessor\":{\"ProcessorConfig\":{\"Mode\":\"INLINE\"},\"StartAt\":\"ExtractTemplateHashes\",\"States\":{\"ExtractTemplateHashes\":{\"End\":true,\"Retry\":[{\"ErrorEquals\":[\"Lambda.ClientExecutionTimeoutException\",\"Lambda.ServiceException\",\"Lambda.AWSLambdaException\",\"Lambda.SdkClientException\"],\"IntervalSeconds\":2,\"MaxAttempts\":6,\"BackoffRate\":2},{\"ErrorEquals\":[\"Throttling\"]}],\"Type\":\"Task\",\"Resource\":\"",
        {
         "Fn::GetAtt": [
          "ToolkitCleanerExtractTemplateHashesFunctionFFDFB6D1",

--- a/test/toolkit-cleaner/toolkit-cleaner.test.ts
+++ b/test/toolkit-cleaner/toolkit-cleaner.test.ts
@@ -28,7 +28,7 @@ test('ToolkitCleaner', () => {
               'Arn',
             ],
           },
-          '"},"StacksMap":{"Type":"Map","Next":"FlattenHashes","ResultSelector":{"AssetHashes.$":"$"},"Iterator":{"StartAt":"ExtractTemplateHashes","States":{"ExtractTemplateHashes":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Throttling"]}],"Type":"Task","Resource":"',
+          '"},"StacksMap":{"Type":"Map","Next":"FlattenHashes","ResultSelector":{"AssetHashes.$":"$"},"ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"ExtractTemplateHashes","States":{"ExtractTemplateHashes":{"End":true,"Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["Throttling"]}],"Type":"Task","Resource":"',
           {
             'Fn::GetAtt': [
               'ToolkitCleanerExtractTemplateHashesFunctionFFDFB6D1',

--- a/test/url-shortener/__snapshots__/url-shortener.test.ts.snap
+++ b/test/url-shortener/__snapshots__/url-shortener.test.ts.snap
@@ -53,7 +53,7 @@ exports[`UrlShortener 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip",
+          "S3Key": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -1183,7 +1183,7 @@ exports[`UrlShortener with API gateway endpoint 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip",
+          "S3Key": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -2658,7 +2658,7 @@ exports[`UrlShortener with CORS 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip",
+          "S3Key": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -3807,7 +3807,7 @@ exports[`UrlShortener with IAM authorization 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip",
+          "S3Key": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -4942,7 +4942,7 @@ exports[`UrlShortener with authorizer 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip",
+          "S3Key": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -6038,7 +6038,7 @@ exports[`UrlShortener with record name 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-eu-west-1",
           },
-          "S3Key": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip",
+          "S3Key": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,

--- a/test/url-shortener/url-shortener.integ.snapshot/edge-lambda-stack-c8e731c8ad0787291628b399d525c90dc78319b7d7.assets.json
+++ b/test/url-shortener/url-shortener.integ.snapshot/edge-lambda-stack-c8e731c8ad0787291628b399d525c90dc78319b7d7.assets.json
@@ -1,5 +1,5 @@
 {
-  "version": "35.0.0",
+  "version": "36.0.0",
   "files": {
     "ef50eada816754194800ebd82b6d5459ee1af84a5fbdfcb142b289e893b6fa07": {
       "source": {

--- a/test/url-shortener/url-shortener.integ.snapshot/url-shortener-integ.assets.json
+++ b/test/url-shortener/url-shortener.integ.snapshot/url-shortener-integ.assets.json
@@ -1,15 +1,15 @@
 {
-  "version": "35.0.0",
+  "version": "36.0.0",
   "files": {
-    "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d": {
+    "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c": {
       "source": {
-        "path": "asset.7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d",
+        "path": "asset.820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-eu-west-1": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1",
-          "objectKey": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip",
+          "objectKey": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip",
           "region": "eu-west-1",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-eu-west-1"
         }
@@ -57,7 +57,7 @@
         }
       }
     },
-    "a8b50926121c6a8d85cc1623e72e0cdddea61d7cef33568a405e9a8a4d51be00": {
+    "50f7d578dfd0bad70f9fb546c7c1c4aa26ef6127c3cfb37e150f9c3807abe461": {
       "source": {
         "path": "url-shortener-integ.template.json",
         "packaging": "file"
@@ -65,7 +65,7 @@
       "destinations": {
         "current_account-eu-west-1": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1",
-          "objectKey": "a8b50926121c6a8d85cc1623e72e0cdddea61d7cef33568a405e9a8a4d51be00.json",
+          "objectKey": "50f7d578dfd0bad70f9fb546c7c1c4aa26ef6127c3cfb37e150f9c3807abe461.json",
           "region": "eu-west-1",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-eu-west-1"
         }

--- a/test/url-shortener/url-shortener.integ.snapshot/url-shortener-integ.template.json
+++ b/test/url-shortener/url-shortener.integ.snapshot/url-shortener-integ.template.json
@@ -1015,7 +1015,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-eu-west-1"
      },
-     "S3Key": "7b6b79862e18ab4b409cd9030e927a51058675765b06850d741b81cd0477a00d.zip"
+     "S3Key": "820cf5767b52fe3ade2023551f65be59f6a5a1d6ffbb11bc6be66146f3c37d3c.zip"
     },
     "Timeout": 900,
     "MemorySize": 128,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-cdk/asset-awscli-v1@^2.2.201":
+"@aws-cdk/asset-awscli-v1@^2.2.202":
   version "2.2.202"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz#4627201d71f6a5c60db36385ce09cb81005f4b32"
   integrity sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==
@@ -3025,22 +3025,23 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.112.0:
-  version "2.112.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.112.0.tgz#42a9e821b95a67636328defd536e3c7bc833d67a"
-  integrity sha512-nrxfXM05Lq6HRoOXdrGXcc1XqqJTtCW3EkjPqdT0kkZ+fR6yQgbzdW2nVxSBiVDNmcf82vLBTmFMezdEgj8N4w==
+aws-cdk-lib@2.133.0:
+  version "2.133.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.133.0.tgz#a70ac4a22333f9b57db8f1a6eb9a9ed03a4a1489"
+  integrity sha512-5/ezv8Ir2xyz3myeXQcODwrjVRN/cDD2OpBwU/ySFBe+uNac25OoHfTXwUPwE7oLj9qetSt6/i1QvY2iIs6yiQ==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.201"
+    "@aws-cdk/asset-awscli-v1" "^2.2.202"
     "@aws-cdk/asset-kubectl-v20" "^2.1.2"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.0.1"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^11.1.1"
-    ignore "^5.3.0"
+    fs-extra "^11.2.0"
+    ignore "^5.3.1"
     jsonschema "^1.4.1"
+    mime-types "^2.1.35"
     minimatch "^3.1.2"
     punycode "^2.3.1"
-    semver "^7.5.4"
+    semver "^7.6.0"
     table "^6.8.1"
     yaml "1.10.2"
 
@@ -4359,7 +4360,7 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.1.1:
+fs-extra@^11.2.0:
   version "11.2.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.2.0.tgz#e70e17dfad64232287d01929399e0ea7c86b0e5b"
   integrity sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==
@@ -4722,7 +4723,7 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.0:
+ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
@@ -5888,7 +5889,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
+mime-types@^2.1.12, mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
Fixes #260 

BREAKING CHANGE: `cloudstructs` now requires `aws-cdk-lib` >= 2.133.0