### PR TITLE
feat(static-website): HTTPS alias record for CloudFront distribution

### DIFF
--- a/src/static-website/index.ts
+++ b/src/static-website/index.ts
@@ -155,6 +155,13 @@ export class StaticWebsite extends Construct {
       target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(this.distribution)),
     });
 
+    new route53.RecordSet(this, 'HttpsRecord', {
+      recordType: 'HTTPS' as route53.RecordType,
+      recordName: props.domainName,
+      zone: props.hostedZone,
+      target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(this.distribution)),
+    })
+
     if (props.backendConfiguration) {
     // Save backend config to bucket, can be queried by the frontend
       new cr.AwsCustomResource(this, 'PutConfig', {

--- a/test/static-website/__snapshots__/static-website.test.ts.snap
+++ b/test/static-website/__snapshots__/static-website.test.ts.snap
@@ -735,6 +735,33 @@ exports[`StaticWebsite 2`] = `
       },
       "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
     },
+    "StaticWebsiteHttpsRecord6CF10F2C": {
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "StaticWebsiteDistributionBAD21F75",
+              "DomainName",
+            ],
+          },
+          "HostedZoneId": {
+            "Fn::FindInMap": [
+              "AWSCloudFrontPartitionHostedZoneIdMap",
+              {
+                "Ref": "AWS::Partition",
+              },
+              "zoneId",
+            ],
+          },
+        },
+        "HostedZoneId": {
+          "Ref": "HostedZoneDB99F866",
+        },
+        "Name": "www.my-site.com.",
+        "Type": "HTTPS",
+      },
+      "Type": "AWS::Route53::RecordSet",
+    },
     "StaticWebsiteHttpsRedirectRedirectAliasRecord2591f3E6FEEF4C": {
       "Properties": {
         "AliasTarget": {


### PR DESCRIPTION
Add a HTTPS DNS alias record for CloudFront distribution

https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-cloudfront-https-dns-records/