### PR TITLE
chore: enable npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: 24.x
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
@@ -126,7 +126,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
   release_maven:
     name: Publish to Maven Central

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -36,6 +36,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   ],
   defaultReleaseBranch: 'master',
   releaseToNpm: true,
+  npmTrustedPublishing: true,
   publishToPypi: {
     distName: 'cloudstructs',
     module: 'cloudstructs',


### PR DESCRIPTION
This change enables OIDC-based authentication for npm publishing, replacing the need for long-lived NPM_TOKEN secrets. The workflow now uses Node.js 24.x (required for npm CLI 11.5.1+) and configures provenance attestation for published packages.

Before this will work in production, the package must be configured on npmjs.com to allow trusted publishing from this GitHub repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)