### PR TITLE
chore: enable PyPI trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
@@ -212,8 +213,7 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi
   release_golang:
     name: Publish to GitHub Go Module Repository

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -40,6 +40,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   publishToPypi: {
     distName: 'cloudstructs',
     module: 'cloudstructs',
+    trustedPublishing: true,
   },
   publishToGo: {
     moduleName: 'github.com/jogold/cloudstructs-go',


### PR DESCRIPTION
This change enables OIDC-based authentication for PyPI publishing, replacing the need for long-lived TWINE_USERNAME and TWINE_PASSWORD secrets. The workflow now uses GitHub's OIDC provider for secure, short-lived credential authentication.

Before this will work in production, the package must be configured on PyPI to allow trusted publishing from this GitHub repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)