### PR TITLE
feat(email-receiver): expose configurable bucket expiration

### DIFF
--- a/API.md
+++ b/API.md
@@ -2382,6 +2382,7 @@ const emailReceiverProps: EmailReceiverProps = { ... }
 | <code><a href="#cloudstructs.EmailReceiverProps.property.recipients">recipients</a></code> | <code>string[]</code> | The recipients for which emails should be received. |
 | <code><a href="#cloudstructs.EmailReceiverProps.property.afterRule">afterRule</a></code> | <code>aws-cdk-lib.aws_ses.IReceiptRule</code> | An existing rule after which the new rule will be placed in the rule set. |
 | <code><a href="#cloudstructs.EmailReceiverProps.property.enabled">enabled</a></code> | <code>boolean</code> | Whether the receiver is active. |
+| <code><a href="#cloudstructs.EmailReceiverProps.property.expiration">expiration</a></code> | <code>aws-cdk-lib.Duration</code> | The expiration for emails stored in the S3 bucket. |
 | <code><a href="#cloudstructs.EmailReceiverProps.property.function">function</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | A Lambda function to invoke after the message is saved to S3. |
 | <code><a href="#cloudstructs.EmailReceiverProps.property.sourceWhitelist">sourceWhitelist</a></code> | <code>string</code> | A regular expression to whitelist source email addresses. |
 
@@ -2434,6 +2435,19 @@ public readonly enabled: boolean;
 - *Default:* true
 
 Whether the receiver is active.
+
+---
+
+##### `expiration`<sup>Optional</sup> <a name="expiration" id="cloudstructs.EmailReceiverProps.property.expiration"></a>
+
+```typescript
+public readonly expiration: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.days(1)
+
+The expiration for emails stored in the S3 bucket.
 
 ---
 

--- a/src/email-receiver/receiver.ts
+++ b/src/email-receiver/receiver.ts
@@ -49,6 +49,13 @@ export interface EmailReceiverProps {
    * @default true
    */
   readonly enabled?: boolean;
+
+  /**
+   * The expiration for emails stored in the S3 bucket.
+   *
+   * @default Duration.days(1)
+   */
+  readonly expiration?: Duration;
 }
 
 /**
@@ -79,7 +86,7 @@ export class EmailReceiver extends Construct {
     this.bucket = new s3.Bucket(this, 'Bucket', {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       encryption: s3.BucketEncryption.S3_MANAGED,
-      lifecycleRules: [{ expiration: Duration.days(1) }],
+      lifecycleRules: [{ expiration: props.expiration ?? Duration.days(1) }],
     });
     if (props.function) {
       this.bucket.grantRead(props.function); // Download email


### PR DESCRIPTION
Add an optional `expiration` prop of type `Duration` on `EmailReceiverProps` so consumers can override the default `Duration.days(1)` lifecycle rule on the S3 bucket where received emails are stored.