### PR TITLE
chore: bump aws-cdk-lib to 2.256.0

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -176,7 +176,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.253.1",
+      "version": "^2.256.0",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -7,7 +7,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   authorAddress: 'jonathan.goldwasser@gmail.com',
   description: 'High-level constructs for AWS CDK',
   jsiiVersion: '5.x',
-  cdkVersion: '2.253.1',
+  cdkVersion: '2.256.0',
   name: 'cloudstructs',
   projenrcTs: true,
   tsJestOptions: { transformOptions: { isolatedModules: true } },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
         "aws-cdk": "^2",
-        "aws-cdk-lib": "2.253.1",
+        "aws-cdk-lib": "2.256.0",
         "aws-sdk-client-mock": "^4.1.0",
         "aws-sdk-client-mock-jest": "^4.1.0",
         "commit-and-tag-version": "^12",
@@ -60,7 +60,7 @@
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.256.0",
         "constructs": "^10.5.1"
       }
     },
@@ -79,9 +79,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.24.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.24.0.tgz",
-      "integrity": "sha512-rCwsd0Y9z4CUmV5FhzjbO2MprXjKG0rxCACuLEY40lD+wInvgcHer0lSDo7Xq9Sxe/IoNe/Wxb2YP3GgxvT3GA==",
+      "version": "53.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.25.0.tgz",
+      "integrity": "sha512-E6Fw6VsG/b8cVwvmbtD9AEkzBWgTaKa6IHNn7CGLli4rdrodnsMmmxwj5Ttml2A82b5coWdNmqsr5nZ0ltKWMw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -89,7 +89,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
+        "jsonschema": "^1.5.0",
         "semver": "^7.8.0"
       },
       "engines": {
@@ -97,7 +97,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5267,9 +5267,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.253.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
-      "integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
+      "version": "2.256.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.256.0.tgz",
+      "integrity": "sha512-MtA5XOSWs+yDA42lW9cO8i+IeCHQt2EwmdPyqWf3li6mF/ptzNxnFjth6rFa5Ms+8v2VzB5cdAS+Ly1ZDGs3fg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -5289,8 +5289,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.2",
-        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -5311,23 +5311,19 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.2",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.4",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -5446,7 +5442,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "aws-cdk": "^2",
-    "aws-cdk-lib": "2.253.1",
+    "aws-cdk-lib": "2.256.0",
     "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-jest": "^4.1.0",
     "commit-and-tag-version": "^12",
@@ -119,7 +119,7 @@
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.256.0",
     "constructs": "^10.5.1"
   },
   "dependencies": {

--- a/test/slack-app/slack-app.integ.snapshot/slack-app-integ.metadata.json
+++ b/test/slack-app/slack-app.integ.snapshot/slack-app-integ.metadata.json
@@ -18,7 +18,7 @@
       "data": [
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:18:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -31,8 +31,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:26:5)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:26:5)"
       ]
     }
   ],
@@ -45,8 +44,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:26:5)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:26:5)"
       ]
     }
   ],
@@ -62,7 +60,7 @@
         "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:144:51)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -78,7 +76,7 @@
         "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:149:22)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -96,7 +94,7 @@
         "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:140:39)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -115,7 +113,7 @@
         "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:140:39)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -133,8 +131,7 @@
         "SlackAppProvider.getOrCreate (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/provider.ts:15:64)",
         "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:140:39)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)"
       ]
     }
   ],
@@ -151,8 +148,7 @@
         "SlackAppProvider.getOrCreate (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/provider.ts:15:64)",
         "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:140:39)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)"
       ]
     }
   ],
@@ -166,9 +162,7 @@
       "data": [
         "...SecretBase.grantRead in aws-cdk-lib...",
         "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:141:36)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)"
       ]
     }
   ],
@@ -183,10 +177,7 @@
         "...new Provider2 in aws-cdk-lib...",
         "new SlackAppProvider (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/provider.ts:31:22)",
         "SlackAppProvider.getOrCreate (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/provider.ts:15:64)",
-        "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:140:39)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:140:39)"
       ]
     }
   ],
@@ -198,13 +189,8 @@
     {
       "type": "aws:cdk:creationStack",
       "data": [
-        "...new Provider2 in aws-cdk-lib...",
-        "new SlackAppProvider (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/provider.ts:31:22)",
-        "SlackAppProvider.getOrCreate (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/provider.ts:15:64)",
-        "new SlackApp (/home/runner/work/cloudstructs/cloudstructs/src/slack-app/slack-app.ts:140:39)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:10:17)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/slack-app/slack-app.integ.ts:25:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...aws-cdk-lib...",
+        "(no user code in 10 frames, use --stack-trace-limit to capture more)"
       ]
     }
   ]

--- a/test/ssl-server-test/ssl-server-test.integ.snapshot/ssl-server-test-integ.metadata.json
+++ b/test/ssl-server-test/ssl-server-test.integ.snapshot/ssl-server-test-integ.metadata.json
@@ -17,8 +17,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:20:5)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:20:5)"
       ]
     }
   ],
@@ -31,8 +30,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:20:5)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:20:5)"
       ]
     }
   ],
@@ -47,8 +45,7 @@
         "...new Schedule2 in aws-cdk-lib...",
         "new SslServerTest (/home/runner/work/cloudstructs/cloudstructs/src/ssl-server-test/index.ts:81:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:19:1)"
       ]
     }
   ],
@@ -64,7 +61,7 @@
         "new SslServerTest (/home/runner/work/cloudstructs/cloudstructs/src/ssl-server-test/index.ts:65:43)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -81,7 +78,7 @@
         "new SslServerTest (/home/runner/work/cloudstructs/cloudstructs/src/ssl-server-test/index.ts:67:29)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -97,7 +94,7 @@
         "new SslServerTest (/home/runner/work/cloudstructs/cloudstructs/src/ssl-server-test/index.ts:81:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -109,11 +106,8 @@
     {
       "type": "aws:cdk:creationStack",
       "data": [
-        "...new Schedule2 in aws-cdk-lib...",
-        "new SslServerTest (/home/runner/work/cloudstructs/cloudstructs/src/ssl-server-test/index.ts:81:5)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...aws-cdk-lib...",
+        "(no user code in 10 frames, use --stack-trace-limit to capture more)"
       ]
     }
   ],
@@ -130,7 +124,7 @@
         "new SslServerTest (/home/runner/work/cloudstructs/cloudstructs/src/ssl-server-test/index.ts:67:29)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -142,11 +136,8 @@
     {
       "type": "aws:cdk:creationStack",
       "data": [
-        "...WrappedClass.grantPublish in aws-cdk-lib...",
-        "new SslServerTest (/home/runner/work/cloudstructs/cloudstructs/src/ssl-server-test/index.ts:79:21)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/ssl-server-test/ssl-server-test.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...aws-cdk-lib...",
+        "(no user code in 10 frames, use --stack-trace-limit to capture more)"
       ]
     }
   ]

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.metadata.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.metadata.json
@@ -17,8 +17,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
       ]
     }
   ],
@@ -31,8 +30,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
       ]
     }
   ],
@@ -47,8 +45,7 @@
         "...new Schedule2 in aws-cdk-lib...",
         "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:90:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)"
       ]
     }
   ],
@@ -65,7 +62,7 @@
         "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:66:27)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -81,7 +78,7 @@
         "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:90:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -93,11 +90,8 @@
     {
       "type": "aws:cdk:creationStack",
       "data": [
-        "...new Schedule2 in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:90:5)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...aws-cdk-lib...",
+        "(no user code in 10 frames, use --stack-trace-limit to capture more)"
       ]
     }
   ],
@@ -114,7 +108,7 @@
         "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:66:27)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -130,7 +124,7 @@
         "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:82:19)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ]

--- a/test/url-shortener/url-shortener.integ.snapshot/url-shortener-integ.metadata.json
+++ b/test/url-shortener/url-shortener.integ.snapshot/url-shortener-integ.metadata.json
@@ -20,7 +20,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:148:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -34,7 +34,7 @@
       "data": [
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:34:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -47,8 +47,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:44:5)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:44:5)"
       ]
     }
   ],
@@ -61,8 +60,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:44:5)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:44:5)"
       ]
     }
   ],
@@ -77,7 +75,7 @@
         "...new UserPool2 in aws-cdk-lib...",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:14:22)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -92,7 +90,7 @@
         "...new CognitoUserPoolsAuthorizer2 in aws-cdk-lib...",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:25:29)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -108,7 +106,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:107:19)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -124,7 +122,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:117:20)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -141,7 +139,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:126:30)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -157,7 +155,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:133:26)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -173,7 +171,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:148:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -189,7 +187,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:149:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -205,7 +203,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:150:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -221,7 +219,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:154:17)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -238,7 +236,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:153:31)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -254,7 +252,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:170:16)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -270,7 +268,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:170:16)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -286,7 +284,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:170:16)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -303,7 +301,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:126:30)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -319,7 +317,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:135:84)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -335,7 +333,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:133:26)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -352,7 +350,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:153:31)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -368,7 +366,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:170:16)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -384,7 +382,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:170:16)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -400,7 +398,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:170:16)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -412,11 +410,8 @@
     {
       "type": "aws:cdk:creationStack",
       "data": [
-        "...WrappedClass.grantRead in aws-cdk-lib...",
-        "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:131:12)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...aws-cdk-lib...",
+        "(no user code in 10 frames, use --stack-trace-limit to capture more)"
       ]
     }
   ],
@@ -431,8 +426,7 @@
         "...new Distribution2 in aws-cdk-lib...",
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:133:26)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)"
       ]
     }
   ],
@@ -444,11 +438,8 @@
     {
       "type": "aws:cdk:creationStack",
       "data": [
-        "...WrappedClass.grantPut in aws-cdk-lib...",
-        "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:166:12)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...aws-cdk-lib...",
+        "(no user code in 10 frames, use --stack-trace-limit to capture more)"
       ]
     }
   ],
@@ -461,10 +452,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new RestApi2 in aws-cdk-lib...",
-        "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:170:16)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:170:16)"
       ]
     }
   ],
@@ -480,7 +468,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:198:19)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -496,7 +484,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:198:19)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -512,7 +500,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:198:19)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ],
@@ -528,7 +516,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:203:8)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -542,9 +530,7 @@
       "data": [
         "...RootResource.addResource in aws-cdk-lib...",
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:203:8)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)"
       ]
     }
   ],
@@ -560,7 +546,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:204:8)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -576,7 +562,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:204:8)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals..."
       ]
     }
   ],
@@ -592,7 +578,7 @@
         "new UrlShortener (/home/runner/work/cloudstructs/cloudstructs/src/url-shortener/index.ts:204:8)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:18:26)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/url-shortener/url-shortener.integ.ts:39:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "...node internals, ts-node..."
       ]
     }
   ]


### PR DESCRIPTION
Pulls in updated bundled dependencies (axios, fast-xml-parser, @aws-sdk/xml-builder) that resolve the vulnerabilities reported by npm audit.

fixes #348