### PR TITLE
fix(toolkit-cleaner): clean function is killed mid-run and can fail permanently in larger accounts

### DIFF
--- a/API.md
+++ b/API.md
@@ -3948,7 +3948,7 @@ const toolkitCleanerProps: ToolkitCleanerProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cloudstructs.ToolkitCleanerProps.property.cleanAssetsTimeout">cleanAssetsTimeout</a></code> | <code>aws-cdk-lib.Duration</code> | The timeout for the clean function. |
+| <code><a href="#cloudstructs.ToolkitCleanerProps.property.cleanAssetsTimeout">cleanAssetsTimeout</a></code> | <code>aws-cdk-lib.Duration</code> | The timeout for the durable execution of the clean function. |
 | <code><a href="#cloudstructs.ToolkitCleanerProps.property.dryRun">dryRun</a></code> | <code>boolean</code> | Only output number of assets and total size that would be deleted but without actually deleting assets. |
 | <code><a href="#cloudstructs.ToolkitCleanerProps.property.retainAssetsNewerThan">retainAssetsNewerThan</a></code> | <code>aws-cdk-lib.Duration</code> | Retain unused assets that were created recently. |
 | <code><a href="#cloudstructs.ToolkitCleanerProps.property.scheduleEnabled">scheduleEnabled</a></code> | <code>boolean</code> | Whether to clean on schedule. |
@@ -3965,7 +3965,10 @@ public readonly cleanAssetsTimeout: Duration;
 - *Type:* aws-cdk-lib.Duration
 - *Default:* Duration.minutes(30)
 
-The timeout for the clean function.
+The timeout for the durable execution of the clean function.
+
+The Lambda function timeout is set to this value, capped at the
+Lambda maximum of 15 minutes.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -3967,9 +3967,6 @@ public readonly cleanAssetsTimeout: Duration;
 
 The timeout for the durable execution of the clean function.
 
-The Lambda function timeout is set to this value, capped at the
-Lambda maximum of 15 minutes.
-
 ---
 
 ##### `dryRun`<sup>Optional</sup> <a name="dryRun" id="cloudstructs.ToolkitCleanerProps.property.dryRun"></a>

--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -41,7 +41,10 @@ export interface ToolkitCleanerProps {
   readonly retainAssetsNewerThan?: Duration;
 
   /**
-   * The timeout for the clean function
+   * The timeout for the durable execution of the clean function.
+   *
+   * The Lambda function timeout is set to this value, capped at the
+   * Lambda maximum of 15 minutes.
    *
    * @default Duration.minutes(30)
    */
@@ -63,10 +66,14 @@ export class ToolkitCleaner extends Construct {
       directory: path.join(__dirname, '..', '..', 'assets', 'toolkit-cleaner', 'docker'),
     });
 
+    const executionTimeout = props.cleanAssetsTimeout ?? Duration.minutes(30);
+
     const cleanFunction = new CleanFunction(this, 'CleanFunction', {
-      timeout: Duration.seconds(30),
+      // The function timeout must cover the longest active phase of the durable
+      // execution, capped at the Lambda maximum of 15 minutes
+      timeout: Duration.seconds(Math.min(executionTimeout.toSeconds(), Duration.minutes(15).toSeconds())),
       durableConfig: {
-        executionTimeout: props.cleanAssetsTimeout ?? Duration.minutes(30),
+        executionTimeout,
       },
       environment: {
         BUCKET_NAME: fileAsset.bucket.bucketName,

--- a/src/toolkit-cleaner/index.ts
+++ b/src/toolkit-cleaner/index.ts
@@ -43,9 +43,6 @@ export interface ToolkitCleanerProps {
   /**
    * The timeout for the durable execution of the clean function.
    *
-   * The Lambda function timeout is set to this value, capped at the
-   * Lambda maximum of 15 minutes.
-   *
    * @default Duration.minutes(30)
    */
   readonly cleanAssetsTimeout?: Duration;
@@ -66,14 +63,13 @@ export class ToolkitCleaner extends Construct {
       directory: path.join(__dirname, '..', '..', 'assets', 'toolkit-cleaner', 'docker'),
     });
 
-    const executionTimeout = props.cleanAssetsTimeout ?? Duration.minutes(30);
-
     const cleanFunction = new CleanFunction(this, 'CleanFunction', {
       // The function timeout must cover the longest active phase of the durable
-      // execution, capped at the Lambda maximum of 15 minutes
-      timeout: Duration.seconds(Math.min(executionTimeout.toSeconds(), Duration.minutes(15).toSeconds())),
+      // execution, so use the Lambda maximum. Not derived from cleanAssetsTimeout
+      // because it may be an unresolved token.
+      timeout: Duration.minutes(15),
       durableConfig: {
-        executionTimeout,
+        executionTimeout: props.cleanAssetsTimeout ?? Duration.minutes(30),
       },
       environment: {
         BUCKET_NAME: fileAsset.bucket.bucketName,

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
@@ -15,30 +15,30 @@
         }
       }
     },
-    "0fadf14b1c7ee09e651a121b6c3d427111bf6f21c40de515de490f09d844743a": {
+    "a0e009c88e76d387b81f7664e748e25ac3fbfc5e7fea8c2ec3e31c5aad0ca808": {
       "displayName": "ToolkitCleaner/CleanFunction/Code",
       "source": {
-        "path": "asset.0fadf14b1c7ee09e651a121b6c3d427111bf6f21c40de515de490f09d844743a.lambda",
+        "path": "asset.a0e009c88e76d387b81f7664e748e25ac3fbfc5e7fea8c2ec3e31c5aad0ca808.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-bb39659e": {
+        "current_account-current_region-2e5ea491": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0fadf14b1c7ee09e651a121b6c3d427111bf6f21c40de515de490f09d844743a.zip",
+          "objectKey": "a0e009c88e76d387b81f7664e748e25ac3fbfc5e7fea8c2ec3e31c5aad0ca808.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "f795a4319d4eb5cb8c06b0958cbd4f157ffeaef8978d5a1967775faa4ddba2bf": {
+    "f3b3eaef73cf7e7ff183e5b8b6425dfd9ae9bc2291af9333027d5837d2e4ca99": {
       "displayName": "toolkit-cleaner-integ Template",
       "source": {
         "path": "toolkit-cleaner-integ.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-f3427ea5": {
+        "current_account-current_region-3b2e54b2": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f795a4319d4eb5cb8c06b0958cbd4f157ffeaef8978d5a1967775faa4ddba2bf.json",
+          "objectKey": "f3b3eaef73cf7e7ff183e5b8b6425dfd9ae9bc2291af9333027d5837d2e4ca99.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.assets.json
@@ -15,30 +15,30 @@
         }
       }
     },
-    "a0e009c88e76d387b81f7664e748e25ac3fbfc5e7fea8c2ec3e31c5aad0ca808": {
+    "0fadf14b1c7ee09e651a121b6c3d427111bf6f21c40de515de490f09d844743a": {
       "displayName": "ToolkitCleaner/CleanFunction/Code",
       "source": {
-        "path": "asset.a0e009c88e76d387b81f7664e748e25ac3fbfc5e7fea8c2ec3e31c5aad0ca808.lambda",
+        "path": "asset.0fadf14b1c7ee09e651a121b6c3d427111bf6f21c40de515de490f09d844743a.lambda",
         "packaging": "zip"
       },
       "destinations": {
-        "current_account-current_region-2e5ea491": {
+        "current_account-current_region-bb39659e": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "a0e009c88e76d387b81f7664e748e25ac3fbfc5e7fea8c2ec3e31c5aad0ca808.zip",
+          "objectKey": "0fadf14b1c7ee09e651a121b6c3d427111bf6f21c40de515de490f09d844743a.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "f3b3eaef73cf7e7ff183e5b8b6425dfd9ae9bc2291af9333027d5837d2e4ca99": {
+    "6fecdc26ebc15158107b90c6990f980ba8d62b96f7c2fbb6f469ba92e17f8152": {
       "displayName": "toolkit-cleaner-integ Template",
       "source": {
         "path": "toolkit-cleaner-integ.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-3b2e54b2": {
+        "current_account-current_region-2155a28f": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f3b3eaef73cf7e7ff183e5b8b6425dfd9ae9bc2291af9333027d5837d2e4ca99.json",
+          "objectKey": "6fecdc26ebc15158107b90c6990f980ba8d62b96f7c2fbb6f469ba92e17f8152.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.metadata.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.metadata.json
@@ -3,8 +3,8 @@
     {
       "type": "aws:cdk:creationStack",
       "data": [
-        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node..."
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "...node internals, ts-node, ts-node, ts-node..."
       ]
     }
   ],
@@ -17,7 +17,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
       ]
     }
   ],
@@ -30,7 +30,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
       ]
     }
   ],
@@ -43,9 +43,9 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Schedule2 in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:94:5)",
-        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)"
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:97:5)",
+        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)"
       ]
     }
   ],
@@ -58,10 +58,10 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Function2 in aws-cdk-lib...",
-        "new CleanFunction (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
-        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:68:27)",
-        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "new CleanFunction (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:71:27)",
+        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node, ts-node..."
       ]
     }
@@ -75,9 +75,9 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Schedule2 in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:94:5)",
-        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:97:5)",
+        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node, ts-node..."
       ]
     }
@@ -104,10 +104,10 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Function2 in aws-cdk-lib...",
-        "new CleanFunction (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
-        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:68:27)",
-        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "new CleanFunction (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:71:27)",
+        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node..."
       ]
     }
@@ -121,9 +121,9 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...CleanFunction.addToRolePolicy in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:86:19)",
-        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:89:19)",
+        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals..."
       ]
     }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.metadata.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.metadata.json
@@ -43,7 +43,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Schedule2 in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:97:5)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:93:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)"
       ]
@@ -59,7 +59,7 @@
       "data": [
         "...new Function2 in aws-cdk-lib...",
         "new CleanFunction (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:71:27)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:66:27)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node, ts-node..."
@@ -75,7 +75,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Schedule2 in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:97:5)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:93:5)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node, ts-node..."
@@ -105,7 +105,7 @@
       "data": [
         "...new Function2 in aws-cdk-lib...",
         "new CleanFunction (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:71:27)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:66:27)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node..."
@@ -121,7 +121,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...CleanFunction.addToRolePolicy in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:89:19)",
+        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:85:19)",
         "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
         "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals..."

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.metadata.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.metadata.json
@@ -3,8 +3,8 @@
     {
       "type": "aws:cdk:creationStack",
       "data": [
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
-        "...node internals, ts-node, ts-node, ts-node..."
+        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "...node internals, ts-node, ts-node..."
       ]
     }
   ],
@@ -17,7 +17,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
+        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
       ]
     }
   ],
@@ -30,7 +30,7 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...App.synth in aws-cdk-lib...",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
+        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:20:5)"
       ]
     }
   ],
@@ -43,9 +43,9 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Schedule2 in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:90:5)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)"
+        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:94:5)",
+        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)"
       ]
     }
   ],
@@ -58,10 +58,10 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Function2 in aws-cdk-lib...",
-        "new CleanFunction (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:66:27)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "new CleanFunction (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
+        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:68:27)",
+        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node, ts-node..."
       ]
     }
@@ -75,9 +75,9 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Schedule2 in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:90:5)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:94:5)",
+        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node, ts-node..."
       ]
     }
@@ -104,10 +104,10 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...new Function2 in aws-cdk-lib...",
-        "new CleanFunction (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:66:27)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "new CleanFunction (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/clean-function.ts:17:5)",
+        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:68:27)",
+        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals, ts-node..."
       ]
     }
@@ -121,9 +121,9 @@
       "type": "aws:cdk:creationStack",
       "data": [
         "...CleanFunction.addToRolePolicy in aws-cdk-lib...",
-        "new ToolkitCleaner (/home/runner/work/cloudstructs/cloudstructs/src/toolkit-cleaner/index.ts:82:19)",
-        "new TestStack (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
-        "<anonymous> (/home/runner/work/cloudstructs/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
+        "new ToolkitCleaner (/home/jogold/projects/cloudstructs/src/toolkit-cleaner/index.ts:86:19)",
+        "new TestStack (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:9:5)",
+        "<anonymous> (/home/jogold/projects/cloudstructs/test/toolkit-cleaner/toolkit-cleaner.integ.ts:19:1)",
         "...node internals..."
       ]
     }

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
@@ -154,7 +154,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "a0e009c88e76d387b81f7664e748e25ac3fbfc5e7fea8c2ec3e31c5aad0ca808.zip"
+     "S3Key": "0fadf14b1c7ee09e651a121b6c3d427111bf6f21c40de515de490f09d844743a.zip"
     },
     "Description": "src/toolkit-cleaner/clean.lambda.ts",
     "DurableConfig": {

--- a/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
+++ b/test/toolkit-cleaner/toolkit-cleaner.integ.snapshot/toolkit-cleaner-integ.template.json
@@ -154,7 +154,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "0fadf14b1c7ee09e651a121b6c3d427111bf6f21c40de515de490f09d844743a.zip"
+     "S3Key": "a0e009c88e76d387b81f7664e748e25ac3fbfc5e7fea8c2ec3e31c5aad0ca808.zip"
     },
     "Description": "src/toolkit-cleaner/clean.lambda.ts",
     "DurableConfig": {
@@ -181,7 +181,7 @@
      ]
     },
     "Runtime": "nodejs24.x",
-    "Timeout": 30
+    "Timeout": 900
    },
    "DependsOn": [
     "ToolkitCleanerCleanFunctionServiceRoleDefaultPolicyBC7E9A9D",

--- a/test/toolkit-cleaner/toolkit-cleaner.test.ts
+++ b/test/toolkit-cleaner/toolkit-cleaner.test.ts
@@ -50,15 +50,15 @@ test('with dry run', () => {
   });
 });
 
-test('with cleanAssetsTimeout shorter than the Lambda maximum', () => {
+test('with cleanAssetsTimeout', () => {
   new ToolkitCleaner(stack, 'ToolkitCleaner', {
-    cleanAssetsTimeout: Duration.minutes(5),
+    cleanAssetsTimeout: Duration.hours(1),
   });
 
   Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
-    Timeout: 300,
+    Timeout: 900,
     DurableConfig: {
-      ExecutionTimeout: 300,
+      ExecutionTimeout: 3600,
     },
   });
 });

--- a/test/toolkit-cleaner/toolkit-cleaner.test.ts
+++ b/test/toolkit-cleaner/toolkit-cleaner.test.ts
@@ -20,7 +20,7 @@ test('ToolkitCleaner', () => {
         DOCKER_IMAGE_ASSET_HASH: Match.anyValue(),
       }),
     },
-    Timeout: 30,
+    Timeout: 900,
     DurableConfig: {
       ExecutionTimeout: 1800,
     },
@@ -46,6 +46,19 @@ test('with dry run', () => {
       Variables: Match.objectLike({
         RUN: Match.absent(),
       }),
+    },
+  });
+});
+
+test('with cleanAssetsTimeout shorter than the Lambda maximum', () => {
+  new ToolkitCleaner(stack, 'ToolkitCleaner', {
+    cleanAssetsTimeout: Duration.minutes(5),
+  });
+
+  Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Function', {
+    Timeout: 300,
+    DurableConfig: {
+      ExecutionTimeout: 300,
     },
   });
 });


### PR DESCRIPTION
The durable `CleanFunction` had a hardcoded 30s Lambda function timeout, while `cleanAssetsTimeout` only set the durable **execution** timeout. The handler is one continuous active phase (stack listing, sequential `GetTemplate` calls, paginated S3/ECR list-and-delete) with no suspension points, so the function timeout must cover the whole run. Accounts with enough stacks or assets exceeded 30s: invocations were killed and recovered from checkpoint (polluting the Lambda `Errors` metric and tripping error alarms), and large enough accounts exhausted the recovery budget so cleanup failed permanently and unused assets silently stopped being reclaimed.

The function timeout is now hardcoded to the Lambda maximum of 15 minutes — it is not derived from `cleanAssetsTimeout` because that duration may wrap an unresolved CDK token, on which arithmetic like `Math.min` silently misbehaves. The execution timeout (default 30 minutes) stays at 2x the function timeout so a killed invocation still has budget to recover from its last checkpoint. The configured timeout is free: Lambda bills actual duration only.

Fixes #362